### PR TITLE
CSDK-2819: Add gcc-4 ABI support on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Libraries are packaged in Twilio style, grouped by variant (debug/release) and t
 
 Unpacking these tarballs into a single directory will create all necessary libraries underneath the abovementioned folders together with a top-level includes/boost directory for headers.
 
-To build packages use ./boost.sh with appropriate argument `-android`, `-ios`, `-osx` or `-linux`.
+To build packages use ./boost.sh with appropriate argument `-android`, `-ios`, `-osx`, `-linux` or `-linux-cxx11-abi-disabled`.
 If not specified, it will attempt to build all. It requires Maven to be installed for deployment - if you do not deploy to Maven-based repositories you can ignore it.
 
 To find the directories from cmake specify two cmake defines, e.g.:

--- a/boost.sh
+++ b/boost.sh
@@ -1424,7 +1424,6 @@ else
    EXTRA_LINUX_FLAGS="$EXTRA_FLAGS"
 fi
 
-
 BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.bz2"
 BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"
 OUTPUT_DIR="$CURRENT_DIR/target/outputs/boost/$BOOST_VERSION"
@@ -1464,6 +1463,7 @@ printf "$format" "BOOST_SRC:" "$BOOST_SRC"
 printf "$format" "ANDROID_NDK_ROOT:" "$ANDROID_NDK_ROOT"
 printf "$format" "ANDROIDBUILDDIR:" "$ANDROIDBUILDDIR"
 printf "$format" "LINUXBUILDDIR:" "$LINUXBUILDDIR"
+printf "$format" "EXTRA_LINUX_FLAGS:" "$EXTRA_LINUX_FLAGS"
 printf "$format" "IOSBUILDDIR:" "$IOSBUILDDIR"
 printf "$format" "OSXBUILDDIR:" "$OSXBUILDDIR"
 printf "$format" "IOSFRAMEWORKDIR:" "$IOSFRAMEWORKDIR"

--- a/boost.sh
+++ b/boost.sh
@@ -92,7 +92,7 @@ OSX_DEV_CMD="xcrun --sdk macosx"
 usage()
 {
 cat << EOF
-usage: $0 [{-android,-ios,-tvos,-osx,-linux,-linux-cxx-11-abi} ...] options
+usage: $0 [{-android,-ios,-tvos,-osx,-linux,-linux-cxx11-abi-disabled} ...] options
 Build Boost for Android, iOS, iOS Simulator, tvOS, tvOS Simulator, OS X, and Linux
 The -ios, -tvos, and -osx options may be specified together.
 
@@ -120,8 +120,8 @@ OPTIONS:
     -linux
         Build for the Linux platform.
 
-    -linux-cxx-11-abi
-        Build for the Linux platform with gcc-4.8 ABI compatibility.
+    -linux-cxx11-abi-disabled
+        Build for the Linux platform without the modern C++11-conforming ABI introduced in GCC 5.
 
     -headers
         Package headers.
@@ -205,9 +205,9 @@ parseArgs()
                 BUILD_LINUX=1
                 ;;
 
-            -linux-cxx-11-abi)
+            -linux-cxx11-abi-disabled)
                 BUILD_LINUX=1
-                USE_CXX11_ABI=1
+                USE_CXX11_ABI=0
                 ;;
 
             -headers)
@@ -1066,8 +1066,8 @@ deployToNexus()
         deployPlat "osx" "$BUILDDIR"
     fi
     if [[ -n "$BUILD_LINUX" ]]; then
-        if [[ -n "$USE_CXX11_ABI" ]]; then
-            deployPlat "linux-cxx-11-abi" "$BUILDDIR"
+        if [[ "$USE_CXX11_ABI" = 0 ]]; then
+            deployPlat "linux-cxx11-abi-disabled" "$BUILDDIR"
         else
             deployPlat "linux" "$BUILDDIR"
         fi
@@ -1419,7 +1419,7 @@ EXTRA_OSX_FLAGS="$EXTRA_FLAGS -mmacosx-version-min=$MIN_OSX_VERSION"
 EXTRA_ANDROID_FLAGS="$EXTRA_FLAGS"
 
 if [[ -n "$USE_CXX11_ABI" ]]; then
-   EXTRA_LINUX_FLAGS="$EXTRA_FLAGS -D_GLIBCXX_USE_CXX11_ABI=0"
+   EXTRA_LINUX_FLAGS="$EXTRA_FLAGS -D_GLIBCXX_USE_CXX11_ABI=$USE_CXX11_ABI"
 else
    EXTRA_LINUX_FLAGS="$EXTRA_FLAGS"
 fi


### PR DESCRIPTION
This PR adds support for a Linux boost variant that is gcc-4 [ABI compatible](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html). Though future releases of Programmable Voice & Video for Linux will move to more modern toolchains, we need to be able to make boost builds using the old ABI in the meantime.

* Added a new platform `-linux-cxx-11-abi` in addition to `-linux`
* Define `USE_CXX11_ABI` variable
* Add `D_GLIBCXX_USE_CXX11_ABI=0` flag when `USE_CXX11_ABI` is set
* Deploy artifacts using the `linux-cxx-11-abi` classifier

#### Validation

I used an Ubuntu 18.04.1 VM running in Parallels with curl, gcc-7, and gcc-multilib. I built both `-linux` and `-linux-cxx-11-abi` platforms. I did not try to deploy artifacts to Bintray using the updated classifier.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.