### PR TITLE
upgrade to android ndk r20b

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,9 @@ jobs:
     steps:
       - run:
           name: apt install
-          command: apt -y --no-install-recommends install libboost-tools-dev rsync
+          command: |
+              apt -y update
+              apt -y --no-install-recommends install libboost-tools-dev rsync
       - unpack
 
   build-headers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,14 @@ aliases:
         type: steps
 
 executors:
-  linux-android-executor:
+  linux-executor:
+    docker:
+      - image: cibuilderbot/docker-circleci-linux-android
+    resource_class: xlarge
+    working_directory: *workspace
+    environment:
+      CMAKE_BUILD_PARALLEL_LEVEL: 2
+  android-executor:
     docker:
       - image: twilio/twilio-video-sdk-toolchain:13
     resource_class: xlarge
@@ -145,35 +152,33 @@ commands:
 
 jobs:
   unpack-sources:
-    executor: linux-android-executor
+    executor: linux-executor
     steps:
       - run:
           name: apt install
-          command: |
-              apt -y update
-              apt -y --no-install-recommends install libboost-tools-dev rsync
+          command: apt -y --no-install-recommends install libboost-tools-dev rsync
       - unpack
 
   build-headers:
-    executor: linux-android-executor
+    executor: linux-executor
     steps:
       - build:
           platform: headers
 
   build-linux:
-    executor: linux-android-executor
+    executor: linux-executor
     steps:
       - build:
           platform: linux
 
   build-linux-cxx11-abi-disabled:
-    executor: linux-android-executor
+    executor: linux-executor
     steps:
       - build:
           platform: linux-cxx11-abi-disabled
 
   build-android:
-    executor: linux-android-executor
+    executor: android-executor
     steps:
       - build:
           platform: android
@@ -197,7 +202,7 @@ jobs:
                 cache-tag: xcode11
 
   deploy-bintray:
-    executor: linux-android-executor
+    executor: linux-executor
     steps:
       - mark-deployment-complete
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ aliases:
 executors:
   linux-android-executor:
     docker:
-      - image: cibuilderbot/docker-circleci-linux-android
+      - image: twilio/twilio-video-sdk-toolchain:13
     resource_class: xlarge
     working_directory: *workspace
     environment:


### PR DESCRIPTION
Uses twilio/twilio-video-sdk-toolchain Docker image to build android with the specified NDK.

Notes:
- The same image breaks linux builds.
- We are hoping to get rid of boost precompiled libraries shortly.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.