### PR TITLE
[CLIENT-7924]  suppress boost version from the archive names.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,10 @@ commands:
             ./boost.sh -<< parameters.platform >> --no-clean --no-unpack --no-framework `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
               `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< parameters.boost-libs >>"
           no_output_timeout: 120m
+      - persist_to_workspace:
+          root: .
+          paths:
+            - target/*
 
 jobs:
   unpack-sources:
@@ -195,6 +199,8 @@ jobs:
       <<: *boost-libs-parameter
     steps:
       - checkout
+      - attach_workspace:
+          at: *workspace
       - generate_build_settings
       - run: #generate_maven_settings
           name: Generate Maven settings
@@ -203,7 +209,7 @@ jobs:
           name: Deploy binaries to bintray
           command: |
             source $BASH_ENV
-            ./boost.sh --deploy `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
+            ./boost.sh --no-clean --no-unpack --no-framework --deploy `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
               `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< parameters.boost-libs >>"
           no_output_timeout: 120m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,8 @@ jobs:
   deploy-bintray:
     executor: linux-executor
     description: "Deploy binaries to bintray"
+    parameters:
+      <<: *boost-libs-parameter
     steps:
       - checkout
       - generate_build_settings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ commands:
           command: |
             if [ -z "$CIRCLE_TAG" ]; then
               echo "Must use release tag to build boost releases. Push \`release-1.71.0-twilio3\`-style tag to trigger."
+              touch $BASH_ENV
             else
               echo 'export BOOST_VERSION=$(echo $CIRCLE_TAG | cut -d - -f 2)' >> $BASH_ENV
               echo 'export TWILIO_SUFFIX=$(echo $CIRCLE_TAG | cut -d - -f 3)' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,6 @@ jobs:
 workflows:
   version: 2
   build-and-deploy:
-    when: << pipeline.parameters.examine-code-changes >>
     jobs:
       - unpack-sources:
           <<: *ignore-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,40 +211,31 @@ workflows:
   build-and-deploy:
     jobs:
       - unpack-sources:
-          <<: *only-release-tags
           name: unpack
-
       - build-headers:
-          <<: *only-release-tags
           name: build-boost-headers
           requires:
             - unpack
       - build-android:
-          <<: *only-release-tags
           name: build-boost-android
           requires:
             - unpack
       - build-linux:
-          <<: *only-release-tags
           name: build-boost-linux
           requires:
             - unpack
       - build-linux-cxx11-abi-disabled:
-          <<: *only-release-tags
           name: build-boost-linux-cxx11-abi-disabled
           requires:
             - unpack
       - build-ios:
-          <<: *only-release-tags
           name: build-boost-ios
           requires:
             - unpack
       - build-osx:
-          <<: *only-release-tags
           name: build-boost-osx
           requires:
             - unpack
-
       - deploy-bintray:
           <<: *only-release-tags
           name: deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   macos-ios-executor:
     macos:
-      xcode: "10.1.0"
+      xcode: "11.0"
     resource_class: large
     working_directory: *workspace
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,12 @@ aliases:
     ~/twilio-boost-build
   - &build_output
     ~/twilio-boost-build/target/output
+  - ignore-master: &ignore-master
+      filters:
+        tags:
+          only: /.*/
+        branches:
+          ignore: /^master/
   - only-release-tags: &only-release-tags
       filters:
         tags:
@@ -53,7 +59,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   macos-ios-executor:
     macos:
-      xcode: "11.0"
+      xcode: "10.1.0"
     resource_class: large
     working_directory: *workspace
 
@@ -204,30 +210,38 @@ jobs:
 workflows:
   version: 2
   build-and-deploy:
+    when: << pipeline.parameters.examine-code-changes >>
     jobs:
       - unpack-sources:
+          <<: *ignore-master
           name: unpack
       - build-headers:
+          <<: *ignore-master
           name: build-boost-headers
           requires:
             - unpack
       - build-android:
+          <<: *ignore-master
           name: build-boost-android
           requires:
             - unpack
       - build-linux:
+          <<: *ignore-master
           name: build-boost-linux
           requires:
             - unpack
       - build-linux-cxx11-abi-disabled:
+          <<: *ignore-master
           name: build-boost-linux-cxx11-abi-disabled
           requires:
             - unpack
       - build-ios:
+          <<: *ignore-master
           name: build-boost-ios
           requires:
             - unpack
       - build-osx:
+          <<: *ignore-master
           name: build-boost-osx
           requires:
             - unpack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,10 @@ commands:
           command: |
             if [ -z "$CIRCLE_TAG" ]; then
               echo "Must use release tag to build boost releases. Push \`release-1.71.0-twilio3\`-style tag to trigger."
-              exit 1
+            else
+              echo 'export BOOST_VERSION=$(echo $CIRCLE_TAG | cut -d - -f 2)' >> $BASH_ENV
+              echo 'export TWILIO_SUFFIX=$(echo $CIRCLE_TAG | cut -d - -f 3)' >> $BASH_ENV
             fi
-            echo 'export BOOST_VERSION=$(echo $CIRCLE_TAG | cut -d - -f 2)' >> $BASH_ENV
-            echo 'export TWILIO_SUFFIX=$(echo $CIRCLE_TAG | cut -d - -f 3)' >> $BASH_ENV
 
   generate_maven_settings:
     description: "Generate Maven settings"
@@ -110,7 +110,8 @@ commands:
           name: Unpack tarball
           command: |
             source $BASH_ENV
-            ./boost.sh --unpack --boost-version $BOOST_VERSION --twilio-suffix -$TWILIO_SUFFIX
+            ./boost.sh --unpack `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
+              `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX`
           no_output_timeout: 120m
       - persist_to_workspace:
           root: .
@@ -134,7 +135,8 @@ commands:
           name: Build << parameters.platform >>
           command: |
             source $BASH_ENV
-            ./boost.sh -<< parameters.platform >> --no-clean --no-unpack --no-framework --boost-version $BOOST_VERSION --twilio-suffix -$TWILIO_SUFFIX --boost-libs "<< parameters.boost-libs >>"
+            ./boost.sh -<< parameters.platform >> --no-clean --no-unpack --no-framework `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
+              `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< parameters.boost-libs >>"
           no_output_timeout: 120m
 
   mark-deployment-complete:
@@ -147,7 +149,8 @@ commands:
           name: Mark all platforms deployed
           command: |
             source $BASH_ENV
-            ./boost.sh --mark-bintray-deployed --boost-version $BOOST_VERSION --twilio-suffix -$TWILIO_SUFFIX
+            ./boost.sh --mark-bintray-deployed `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
+              `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX`
           no_output_timeout: 120m
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,13 +72,6 @@ commands:
               echo 'export TWILIO_SUFFIX=$(echo $CIRCLE_TAG | cut -d - -f 3)' >> $BASH_ENV
             fi
 
-  generate_maven_settings:
-    description: "Generate Maven settings"
-    steps:
-      - run:
-          name: Generate Maven settings
-          command: echo "$BINTRAY_SETTINGS" | base64 --decode > bintray-settings.xml
-
   prepare_macos_ios:
     description: "Prepare environment for MacOS and iOS builds (cache enabled)"
     parameters:
@@ -106,7 +99,6 @@ commands:
     steps:
       - checkout
       - generate_build_settings
-      - generate_maven_settings
       - run:
           name: Unpack tarball
           command: |
@@ -131,27 +123,12 @@ commands:
       - attach_workspace:
           at: *workspace
       - generate_build_settings
-      - generate_maven_settings
       - run:
           name: Build << parameters.platform >>
           command: |
             source $BASH_ENV
             ./boost.sh -<< parameters.platform >> --no-clean --no-unpack --no-framework `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
               `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< parameters.boost-libs >>"
-          no_output_timeout: 120m
-
-  mark-deployment-complete:
-    description: "Mark all deployed binaries as available for download"
-    steps:
-      - checkout
-      - generate_build_settings
-      - generate_maven_settings
-      - run:
-          name: Mark all platforms deployed
-          command: |
-            source $BASH_ENV
-            ./boost.sh --mark-bintray-deployed `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
-              `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX`
           no_output_timeout: 120m
 
 jobs:
@@ -207,8 +184,20 @@ jobs:
 
   deploy-bintray:
     executor: linux-executor
+    description: "Deploy binaries to bintray"
     steps:
-      - mark-deployment-complete
+      - checkout
+      - generate_build_settings
+      - run: #generate_maven_settings
+          name: Generate Maven settings
+          command: echo "$BINTRAY_SETTINGS" | base64 --decode > bintray-settings.xml
+      - run:
+          name: Deploy binaries to bintray
+          command: |
+            source $BASH_ENV
+            ./boost.sh --deploy `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
+              `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< parameters.boost-libs >>"
+          no_output_timeout: 120m
 
 workflows:
   version: 2

--- a/boost.sh
+++ b/boost.sh
@@ -1137,32 +1137,6 @@ deployPlat()
     done
 }
 
-deployToNexus()
-{
-    BUILDDIR="$CURRENT_DIR/target/distributions"
-
-    if [[ -n "$BUILD_HEADERS" ]]; then
-        deployFile boost-headers "${BUILDDIR}/boost-headers-${BOOST_VERSION}${TWILIO_SUFFIX}-all.tar.bz2" all ${BOOST_VERSION}${TWILIO_SUFFIX}
-    fi
-
-    if [[ -n "$BUILD_ANDROID" ]]; then
-        deployPlat "android" "$BUILDDIR"
-    fi
-    if [[ -n "$BUILD_IOS" ]]; then
-        deployPlat "ios" "$BUILDDIR"
-    fi
-    if [[ -n "$BUILD_OSX" ]]; then
-        deployPlat "osx" "$BUILDDIR"
-    fi
-    if [[ -n "$BUILD_LINUX" ]]; then
-        if [[ "$USE_CXX11_ABI" == 0 ]]; then
-            deployPlat "linux-cxx11-abi-disabled" "$BUILDDIR"
-        else
-            deployPlat "linux" "$BUILDDIR"
-        fi
-    fi
-}
-
 deployToBintray()
 {
     if [[ -z "$REPO_ID" ]]; then
@@ -1170,11 +1144,13 @@ deployToBintray()
     fi
 
     BUILDDIR="$CURRENT_DIR/target/distributions"
-    SETTINGS_FILE="$CURRENT_DIR/bintray-settings.xml"
-
     SETTINGS_FILE="-s $SETTINGS_FILE"
-
-    deployToNexus
+    deployFile boost-headers "${BUILDDIR}/boost-headers-${BOOST_VERSION}${TWILIO_SUFFIX}-all.tar.bz2" all ${BOOST_VERSION}${TWILIO_SUFFIX}
+    deployPlat "android" "$BUILDDIR"
+    deployPlat "ios" "$BUILDDIR"
+    deployPlat "osx" "$BUILDDIR"
+    deployPlat "linux-cxx11-abi-disabled" "$BUILDDIR"
+    deployPlat "linux" "$BUILDDIR"
 }
 
 #===============================================================================
@@ -1451,16 +1427,7 @@ if [[ -z $BOOST_VERSION ]]; then
     BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"
 fi
 
-if [[ -z $UNPACK && -z $BUILD_IOS && -z $BUILD_TVOS && -z $BUILD_OSX && -z $BUILD_ANDROID && -z $BUILD_LINUX && -z $BUILD_HEADERS ]]; then
-    BUILD_ANDROID=1
-    BUILD_IOS=1
-    BUILD_TVOS=1
-    BUILD_OSX=1
-    BUILD_LINUX=1
-    BUILD_HEADERS=1
-fi
-
-if [[ -n $UNPACK ]]; then
+if [[ -n $UNPACK || -n $DEPLOY ]]; then
     NO_DOWNLOAD=
     BUILD_ANDROID=
     BUILD_IOS=
@@ -1468,6 +1435,13 @@ if [[ -n $UNPACK ]]; then
     BUILD_OSX=
     BUILD_LINUX=
     BUILD_HEADERS=
+elif [[ -z $BUILD_IOS && -z $BUILD_TVOS && -z $BUILD_OSX && -z $BUILD_ANDROID && -z $BUILD_LINUX && -z $BUILD_HEADERS ]]; then
+    BUILD_ANDROID=1
+    BUILD_IOS=1
+    BUILD_TVOS=1
+    BUILD_OSX=1
+    BUILD_LINUX=1
+    BUILD_HEADERS=1
 fi
 
 # The EXTRA_FLAGS definition works around a thread race issue in

--- a/boost.sh
+++ b/boost.sh
@@ -1632,4 +1632,3 @@ else
 fi
 
 echo "Completed successfully"
-

--- a/boost.sh
+++ b/boost.sh
@@ -1055,6 +1055,20 @@ packageHeaders()
 
 #===============================================================================
 
+renameArchives()
+{
+    echo Renaming boost archives...
+
+    {
+        cd $OUTPUT_DIR;
+        find lib -type f libboost_${BOOST_VERSION2}*.a | while read archive; do
+            mv -v $archive ${archive/${BOOST_VERSION2}/};
+        done;
+    }
+}
+
+#===============================================================================
+
 packageLibEntry()
 {
     BUILDDIR="$CURRENT_DIR/target/distributions"
@@ -1065,11 +1079,11 @@ packageLibEntry()
     echo Packaging boost-$NAME...
 
     if [[ -z "$2" ]]; then
-        PATTERN="-name *libboost_${BOOST_VERSION2}_${NAME}*"
+        PATTERN="-name libboost_${BOOST_VERSION2}_${NAME}*.a"
     else
         PATTERN="-name NOTMATCHED"
         for PAT in $2; do
-            PATTERN="$PATTERN -o -name *libboost_${BOOST_VERSION2}_${PAT}*"
+            PATTERN="$PATTERN -o -name libboost_${BOOST_VERSION2}_${PAT}*.a"
         done
     fi
 
@@ -1607,6 +1621,7 @@ if [[ -n "$BUILD_HEADERS" ]]; then
 fi
 
 if [[ -z $NO_PACKAGE_LIBS ]]; then
+    renameArchives
     packageLibSet
 fi
 

--- a/boost.sh
+++ b/boost.sh
@@ -46,9 +46,6 @@ NO_PACKAGE_LIBS=
 NO_UNPACK=
 MARK_DEPLOYED_ONLY=
 
-BOOST_VERSION=1.69.0
-BOOST_VERSION2=1_69_0
-
 ASYNC_COMMIT=94fe4433287df569ce1aa384b248793552980711
 
 TWILIO_SUFFIX=
@@ -1454,6 +1451,14 @@ EOF
 #===============================================================================
 
 parseArgs "$@"
+
+if [[ -z $BOOST_VERSION ]]; then
+    BOOST_VERSION=`curl -s 'https://www.boost.org' | sed -n 's/.*https:\/\/dl\.bintray\.com\/boostorg\/release\/\([^\/]*\)\/.*$/\1/p'`
+    echo "Detecting the latest boost version from https://www.boost.org to be version $BOOST_VERSION"
+    BOOST_VERSION2="${BOOST_VERSION//./_}"
+    BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.bz2"
+    BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"
+fi
 
 if [[ -z $UNPACK && -z $BUILD_IOS && -z $BUILD_TVOS && -z $BUILD_OSX && -z $BUILD_ANDROID && -z $BUILD_LINUX && -z $BUILD_HEADERS ]]; then
     BUILD_ANDROID=1

--- a/boost.sh
+++ b/boost.sh
@@ -44,7 +44,7 @@ NO_FRAMEWORK=
 USE_CXX11_ABI=
 NO_PACKAGE_LIBS=
 NO_UNPACK=
-MARK_DEPLOYED_ONLY=
+DEPLOY=
 
 ASYNC_COMMIT=94fe4433287df569ce1aa384b248793552980711
 
@@ -353,8 +353,8 @@ parseArgs()
                 NO_UNPACK=1
                 ;;
 
-            --mark-bintray-deployed)
-                MARK_DEPLOYED_ONLY=1
+            --deploy)
+                DEPLOY=1
                 ;;
 
             *)
@@ -1177,15 +1177,6 @@ deployToBintray()
     deployToNexus
 }
 
-markBintrayDeployed()
-{
-    echo "All is published, hurray!"
-    # SETTINGS_FILE="$CURRENT_DIR/bintray-settings.xml"
-    # BINTRAY_USERNAME:BINTRAY_PASSWORD...
-    # curl -X POST ${BINTRAY_API_URL}/content/${REPO_URL_FRAGMENT}/:version/publish
-    # https://api.bintray.com/content/twilio/releases/rtd-cpp-boost-lib/$VERSION/publish
-}
-
 #===============================================================================
 
 unpackArchive()
@@ -1479,21 +1470,6 @@ if [[ -n $UNPACK ]]; then
     BUILD_HEADERS=
 fi
 
-if [[ -n $MARK_DEPLOYED_ONLY ]]; then
-    CLEAN=
-    NO_CLEAN=1
-    UNPACK=
-    NO_DOWNLOAD=1
-    BUILD_ANDROID=
-    BUILD_IOS=
-    BUILD_TVOS=
-    BUILD_OSX=
-    BUILD_LINUX=
-    BUILD_HEADERS=
-    NO_FRAMEWORK=1
-    NO_PACKAGE_LIBS=1
-fi
-
 # The EXTRA_FLAGS definition works around a thread race issue in
 # shared_ptr. I encountered this historically and have not verified that
 # the fix is no longer required. Without using the posix thread primitives
@@ -1630,10 +1606,8 @@ if [[ -z $NO_PACKAGE_LIBS ]]; then
     packageLibSet
 fi
 
-if [[ -z $MARK_DEPLOYED_ONLY ]]; then
+if [[ -n "$DEPLOY" ]]; then
     deployToBintray
-else
-    markBintrayDeployed
 fi
 
 echo "Completed successfully"

--- a/boost.sh
+++ b/boost.sh
@@ -1058,7 +1058,7 @@ renameArchives()
 
     {
         cd $OUTPUT_DIR;
-        find lib -type f libboost_${BOOST_VERSION2}*.a | while read archive; do
+        find lib -type f -name libboost_${BOOST_VERSION2}*.a | while read archive; do
             mv -v $archive ${archive/${BOOST_VERSION2}/};
         done;
     }

--- a/boost.sh
+++ b/boost.sh
@@ -1134,7 +1134,7 @@ deployToBintray()
     fi
 
     BUILDDIR="$CURRENT_DIR/target/distributions"
-    SETTINGS_FILE="-s $SETTINGS_FILE"
+    SETTINGS_FILE="-s $CURRENT_DIR/bintray-settings.xml"
     deployFile boost-headers "${BUILDDIR}/boost-headers-${BOOST_VERSION}${TWILIO_SUFFIX}-all.tar.bz2" all ${BOOST_VERSION}${TWILIO_SUFFIX}
     deployPlat "android" "$BUILDDIR"
     deployPlat "ios" "$BUILDDIR"

--- a/boost.sh
+++ b/boost.sh
@@ -1059,7 +1059,7 @@ renameArchives()
     {
         cd $OUTPUT_DIR;
         find lib -type f -name libboost_${BOOST_VERSION2}*.a | while read archive; do
-            mv -v $archive ${archive/${BOOST_VERSION2}/};
+            mv -v $archive ${archive/${BOOST_VERSION2}_/};
         done;
     }
 }
@@ -1076,11 +1076,11 @@ packageLibEntry()
     echo Packaging boost-$NAME...
 
     if [[ -z "$2" ]]; then
-        PATTERN="-name libboost_${BOOST_VERSION2}_${NAME}*.a"
+        PATTERN="-name libboost_${NAME}*.a"
     else
         PATTERN="-name NOTMATCHED"
         for PAT in $2; do
-            PATTERN="$PATTERN -o -name libboost_${BOOST_VERSION2}_${PAT}*.a"
+            PATTERN="$PATTERN -o -name libboost_${PAT}*.a"
         done
     fi
 

--- a/boost.sh
+++ b/boost.sh
@@ -1632,3 +1632,4 @@ else
 fi
 
 echo "Completed successfully"
+


### PR DESCRIPTION
The usage of BCP renamed the boost archives adding its version. To ease maintenance, we want to revert that and produce archives without the version on it.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.