### PR TITLE
CSDK-3681: Add iOS 9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       boost-libs:
         description: "List of boost libraries to build"
         type: string
-        default: "atomic context coroutine date_time exception iostreams program_options random regex serialization system test thread"
+        default: "atomic context coroutine date_time exception iostreams program_options random regex system test thread"
   - pre-steps-parameter: &pre-steps-parameter
       pre-steps:
         description: "Steps that will be executed before build starts"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ aliases:
       boost-libs:
         description: "List of boost libraries to build"
         type: string
+        # We removed serialization as we need to be able to build for iOS 9 and there are code that is using iOS 10+ features
         default: "atomic context coroutine date_time exception iostreams program_options random regex system test thread"
   - pre-steps-parameter: &pre-steps-parameter
       pre-steps:

--- a/boost.sh
+++ b/boost.sh
@@ -54,7 +54,7 @@ REPO_URL_FRAGMENT=twilio/releases/rtd-cpp-boost-lib
 REPO_URL="${BINTRAY_API_URL}/maven/${REPO_URL_FRAGMENT}/;publish=0"
 REPO_ID=bintray
 
-MIN_IOS_VERSION=10.0
+MIN_IOS_VERSION=9.0
 
 MIN_TVOS_VERSION=9.2
 


### PR DESCRIPTION
We have a requirement to add iOS 9 support. There was an issue compiling `serialization` due to it using code that was added in iOS 10. I removed building of `serialization` from the libraries as we are not currently using it. Not sure if anybody else is using it.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
