### PR TITLE
Backport beast partial deflate block fixes to boost 1.72 and 1.73

### DIFF
--- a/patches/boost_1_72_0_fix_beast_partial_deflate_block.patch
+++ b/patches/boost_1_72_0_fix_beast_partial_deflate_block.patch
@@ -1,0 +1,118 @@
+Backporting fixes for when a received deflate block spans multiple multi_byte character arrays.
+Reference: https://github.com/boostorg/beast/pull/2191
+--- a/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 15:42:22.000000000 -0700
++++ b/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 15:49:42.000000000 -0700
+@@ -471,6 +471,7 @@
+                         zs.avail_out = out.size();
+                         BOOST_ASSERT(zs.avail_out > 0);
+                     }
++                    bool fin = false;
+                     if(impl.rd_remain > 0)
+                     {
+                         if(impl.rd_buf.size() > 0)
+@@ -494,18 +495,7 @@
+                             empty_block[4] = { 0x00, 0x00, 0xff, 0xff };
+                         zs.next_in = empty_block;
+                         zs.avail_in = sizeof(empty_block);
+-                        impl.inflate(zs, zlib::Flush::sync, ec);
+-                        if(! ec)
+-                        {
+-                            // https://github.com/madler/zlib/issues/280
+-                            if(zs.total_out > 0)
+-                                ec = error::partial_deflate_block;
+-                        }
+-                        if(impl.check_stop_now(ec))
+-                            goto upcall;
+-                        impl.do_context_takeover_read(impl.role);
+-                        impl.rd_done = true;
+-                        break;
++                        fin = true;
+                     }
+                     else
+                     {
+@@ -514,6 +504,15 @@
+                     impl.inflate(zs, zlib::Flush::sync, ec);
+                     if(impl.check_stop_now(ec))
+                         goto upcall;
++                    if (fin) {
++                        if (zs.total_out == 0) {
++                            impl.do_context_takeover_read(impl.role);
++                            impl.rd_done = true;
++                            break;
++                        } else {
++                            printf("-> partial_deflate_block %lu <-\n", zs.total_out);
++                        }
++                    }
+                     if(impl.rd_msg_max && beast::detail::sum_exceeds(
+                         impl.rd_size, zs.total_out, impl.rd_msg_max))
+                     {
+@@ -524,8 +523,10 @@
+                     }
+                     cb_.consume(zs.total_out);
+                     impl.rd_size += zs.total_out;
+-                    impl.rd_remain -= zs.total_in;
+-                    impl.rd_buf.consume(zs.total_in);
++                    if (!fin) {
++                        impl.rd_remain -= zs.total_in;
++                        impl.rd_buf.consume(zs.total_in);
++                    }
+                     bytes_written_ += zs.total_out;
+                 }
+                 if(impl.rd_op == detail::opcode::text)
+@@ -1165,6 +1166,7 @@
+                 zs.avail_out = out.size();
+                 BOOST_ASSERT(zs.avail_out > 0);
+             }
++            bool fin = false;
+             if(impl.rd_remain > 0)
+             {
+                 if(impl.rd_buf.size() > 0)
+@@ -1212,18 +1214,7 @@
+                         0x00, 0x00, 0xff, 0xff };
+                 zs.next_in = empty_block;
+                 zs.avail_in = sizeof(empty_block);
+-                impl.inflate(zs, zlib::Flush::sync, ec);
+-                if(! ec)
+-                {
+-                    // https://github.com/madler/zlib/issues/280
+-                    if(zs.total_out > 0)
+-                        ec = error::partial_deflate_block;
+-                }
+-                if(impl.check_stop_now(ec))
+-                    return bytes_written;
+-                impl.do_context_takeover_read(impl.role);
+-                impl.rd_done = true;
+-                break;
++                fin = true;
+             }
+             else
+             {
+@@ -1232,6 +1223,15 @@
+             impl.inflate(zs, zlib::Flush::sync, ec);
+             if(impl.check_stop_now(ec))
+                 return bytes_written;
++            if (fin) {
++                if (zs.total_out == 0) {
++                    impl.do_context_takeover_read(impl.role);
++                    impl.rd_done = true;
++                    break;
++                } else {
++                    printf("-> partial_deflate_block %lu <-\n", zs.total_out);
++                }
++            }
+             if(impl.rd_msg_max && beast::detail::sum_exceeds(
+                 impl.rd_size, zs.total_out, impl.rd_msg_max))
+             {
+@@ -1241,8 +1241,10 @@
+             }
+             cb.consume(zs.total_out);
+             impl.rd_size += zs.total_out;
+-            impl.rd_remain -= zs.total_in;
+-            impl.rd_buf.consume(zs.total_in);
++            if (!fin) {
++                impl.rd_remain -= zs.total_in;
++                impl.rd_buf.consume(zs.total_in);
++            }
+             bytes_written += zs.total_out;
+         }
+         if(impl.rd_op == detail::opcode::text)

--- a/patches/boost_1_72_0_fix_beast_partial_deflate_block.patch
+++ b/patches/boost_1_72_0_fix_beast_partial_deflate_block.patch
@@ -1,7 +1,5 @@
-Backporting fixes for when a received deflate block spans multiple multi_byte character arrays.
-Reference: https://github.com/boostorg/beast/pull/2191
 --- a/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 15:42:22.000000000 -0700
-+++ b/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 15:49:42.000000000 -0700
++++ b/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 19:33:59.000000000 -0700
 @@ -471,6 +471,7 @@
                          zs.avail_out = out.size();
                          BOOST_ASSERT(zs.avail_out > 0);
@@ -10,7 +8,12 @@ Reference: https://github.com/boostorg/beast/pull/2191
                      if(impl.rd_remain > 0)
                      {
                          if(impl.rd_buf.size() > 0)
-@@ -494,18 +495,7 @@
+@@ -490,22 +491,11 @@
+                     else if(impl.rd_fh.fin)
+                     {
+                         // append the empty block codes
+-                        std::uint8_t constexpr
++                        static std::uint8_t constexpr
                              empty_block[4] = { 0x00, 0x00, 0xff, 0xff };
                          zs.next_in = empty_block;
                          zs.avail_in = sizeof(empty_block);
@@ -30,7 +33,7 @@ Reference: https://github.com/boostorg/beast/pull/2191
                      }
                      else
                      {
-@@ -514,6 +504,15 @@
+@@ -514,6 +504,13 @@
                      impl.inflate(zs, zlib::Flush::sync, ec);
                      if(impl.check_stop_now(ec))
                          goto upcall;
@@ -39,14 +42,12 @@ Reference: https://github.com/boostorg/beast/pull/2191
 +                            impl.do_context_takeover_read(impl.role);
 +                            impl.rd_done = true;
 +                            break;
-+                        } else {
-+                            printf("-> partial_deflate_block %lu <-\n", zs.total_out);
 +                        }
 +                    }
                      if(impl.rd_msg_max && beast::detail::sum_exceeds(
                          impl.rd_size, zs.total_out, impl.rd_msg_max))
                      {
-@@ -524,8 +523,10 @@
+@@ -524,8 +521,10 @@
                      }
                      cb_.consume(zs.total_out);
                      impl.rd_size += zs.total_out;
@@ -59,7 +60,7 @@ Reference: https://github.com/boostorg/beast/pull/2191
                      bytes_written_ += zs.total_out;
                  }
                  if(impl.rd_op == detail::opcode::text)
-@@ -1165,6 +1166,7 @@
+@@ -1165,6 +1164,7 @@
                  zs.avail_out = out.size();
                  BOOST_ASSERT(zs.avail_out > 0);
              }
@@ -67,8 +68,13 @@ Reference: https://github.com/boostorg/beast/pull/2191
              if(impl.rd_remain > 0)
              {
                  if(impl.rd_buf.size() > 0)
-@@ -1212,18 +1214,7 @@
-                         0x00, 0x00, 0xff, 0xff };
+@@ -1208,22 +1208,10 @@
+             {
+                 // append the empty block codes
+                 static std::uint8_t constexpr
+-                    empty_block[4] = {
+-                        0x00, 0x00, 0xff, 0xff };
++                    empty_block[4] = { 0x00, 0x00, 0xff, 0xff };
                  zs.next_in = empty_block;
                  zs.avail_in = sizeof(empty_block);
 -                impl.inflate(zs, zlib::Flush::sync, ec);
@@ -87,7 +93,7 @@ Reference: https://github.com/boostorg/beast/pull/2191
              }
              else
              {
-@@ -1232,6 +1223,15 @@
+@@ -1232,6 +1220,13 @@
              impl.inflate(zs, zlib::Flush::sync, ec);
              if(impl.check_stop_now(ec))
                  return bytes_written;
@@ -96,14 +102,12 @@ Reference: https://github.com/boostorg/beast/pull/2191
 +                    impl.do_context_takeover_read(impl.role);
 +                    impl.rd_done = true;
 +                    break;
-+                } else {
-+                    printf("-> partial_deflate_block %lu <-\n", zs.total_out);
 +                }
 +            }
              if(impl.rd_msg_max && beast::detail::sum_exceeds(
                  impl.rd_size, zs.total_out, impl.rd_msg_max))
              {
-@@ -1241,8 +1241,10 @@
+@@ -1241,8 +1236,10 @@
              }
              cb.consume(zs.total_out);
              impl.rd_size += zs.total_out;

--- a/patches/boost_1_72_0_fix_beast_partial_deflate_block.patch
+++ b/patches/boost_1_72_0_fix_beast_partial_deflate_block.patch
@@ -1,5 +1,8 @@
+Backporting fixes for when a received deflate block spans multiple multi_byte character arrays when inflated.
+Reference: https://github.com/boostorg/beast/pull/2191
+
 --- a/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 15:42:22.000000000 -0700
-+++ b/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 19:33:59.000000000 -0700
++++ b/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-18 14:31:12.000000000 -0700
 @@ -471,6 +471,7 @@
                          zs.avail_out = out.size();
                          BOOST_ASSERT(zs.avail_out > 0);
@@ -37,30 +40,31 @@
                      impl.inflate(zs, zlib::Flush::sync, ec);
                      if(impl.check_stop_now(ec))
                          goto upcall;
-+                    if (fin) {
-+                        if (zs.total_out == 0) {
++                    if(fin)
++                        if(zs.total_out == 0)
++                        {
 +                            impl.do_context_takeover_read(impl.role);
 +                            impl.rd_done = true;
 +                            break;
 +                        }
-+                    }
                      if(impl.rd_msg_max && beast::detail::sum_exceeds(
                          impl.rd_size, zs.total_out, impl.rd_msg_max))
                      {
-@@ -524,8 +521,10 @@
+@@ -524,8 +521,11 @@
                      }
                      cb_.consume(zs.total_out);
                      impl.rd_size += zs.total_out;
 -                    impl.rd_remain -= zs.total_in;
 -                    impl.rd_buf.consume(zs.total_in);
-+                    if (!fin) {
++                    if(! fin)
++                    {
 +                        impl.rd_remain -= zs.total_in;
 +                        impl.rd_buf.consume(zs.total_in);
 +                    }
                      bytes_written_ += zs.total_out;
                  }
                  if(impl.rd_op == detail::opcode::text)
-@@ -1165,6 +1164,7 @@
+@@ -1165,6 +1165,7 @@
                  zs.avail_out = out.size();
                  BOOST_ASSERT(zs.avail_out > 0);
              }
@@ -68,7 +72,7 @@
              if(impl.rd_remain > 0)
              {
                  if(impl.rd_buf.size() > 0)
-@@ -1208,22 +1208,10 @@
+@@ -1208,22 +1209,10 @@
              {
                  // append the empty block codes
                  static std::uint8_t constexpr
@@ -93,27 +97,28 @@
              }
              else
              {
-@@ -1232,6 +1220,13 @@
+@@ -1232,6 +1221,13 @@
              impl.inflate(zs, zlib::Flush::sync, ec);
              if(impl.check_stop_now(ec))
                  return bytes_written;
-+            if (fin) {
-+                if (zs.total_out == 0) {
++            if(fin)
++                if(zs.total_out == 0)
++                {
 +                    impl.do_context_takeover_read(impl.role);
 +                    impl.rd_done = true;
 +                    break;
 +                }
-+            }
              if(impl.rd_msg_max && beast::detail::sum_exceeds(
                  impl.rd_size, zs.total_out, impl.rd_msg_max))
              {
-@@ -1241,8 +1236,10 @@
+@@ -1241,8 +1237,11 @@
              }
              cb.consume(zs.total_out);
              impl.rd_size += zs.total_out;
 -            impl.rd_remain -= zs.total_in;
 -            impl.rd_buf.consume(zs.total_in);
-+            if (!fin) {
++            if(! fin)
++            {
 +                impl.rd_remain -= zs.total_in;
 +                impl.rd_buf.consume(zs.total_in);
 +            }

--- a/patches/boost_1_73_0_fix_beast_partial_deflate_block.patch
+++ b/patches/boost_1_73_0_fix_beast_partial_deflate_block.patch
@@ -1,0 +1,118 @@
+Backporting fixes for when a received deflate block spans multiple multi_byte character arrays.
+Reference: https://github.com/boostorg/beast/pull/2191
+--- a/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 15:42:22.000000000 -0700
++++ b/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 15:49:42.000000000 -0700
+@@ -471,6 +471,7 @@
+                         zs.avail_out = out.size();
+                         BOOST_ASSERT(zs.avail_out > 0);
+                     }
++                    bool fin = false;
+                     if(impl.rd_remain > 0)
+                     {
+                         if(impl.rd_buf.size() > 0)
+@@ -494,18 +495,7 @@
+                             empty_block[4] = { 0x00, 0x00, 0xff, 0xff };
+                         zs.next_in = empty_block;
+                         zs.avail_in = sizeof(empty_block);
+-                        impl.inflate(zs, zlib::Flush::sync, ec);
+-                        if(! ec)
+-                        {
+-                            // https://github.com/madler/zlib/issues/280
+-                            if(zs.total_out > 0)
+-                                ec = error::partial_deflate_block;
+-                        }
+-                        if(impl.check_stop_now(ec))
+-                            goto upcall;
+-                        impl.do_context_takeover_read(impl.role);
+-                        impl.rd_done = true;
+-                        break;
++                        fin = true;
+                     }
+                     else
+                     {
+@@ -514,6 +504,15 @@
+                     impl.inflate(zs, zlib::Flush::sync, ec);
+                     if(impl.check_stop_now(ec))
+                         goto upcall;
++                    if (fin) {
++                        if (zs.total_out == 0) {
++                            impl.do_context_takeover_read(impl.role);
++                            impl.rd_done = true;
++                            break;
++                        } else {
++                            printf("-> partial_deflate_block %lu <-\n", zs.total_out);
++                        }
++                    }
+                     if(impl.rd_msg_max && beast::detail::sum_exceeds(
+                         impl.rd_size, zs.total_out, impl.rd_msg_max))
+                     {
+@@ -524,8 +523,10 @@
+                     }
+                     cb_.consume(zs.total_out);
+                     impl.rd_size += zs.total_out;
+-                    impl.rd_remain -= zs.total_in;
+-                    impl.rd_buf.consume(zs.total_in);
++                    if (!fin) {
++                        impl.rd_remain -= zs.total_in;
++                        impl.rd_buf.consume(zs.total_in);
++                    }
+                     bytes_written_ += zs.total_out;
+                 }
+                 if(impl.rd_op == detail::opcode::text)
+@@ -1165,6 +1166,7 @@
+                 zs.avail_out = out.size();
+                 BOOST_ASSERT(zs.avail_out > 0);
+             }
++            bool fin = false;
+             if(impl.rd_remain > 0)
+             {
+                 if(impl.rd_buf.size() > 0)
+@@ -1212,18 +1214,7 @@
+                         0x00, 0x00, 0xff, 0xff };
+                 zs.next_in = empty_block;
+                 zs.avail_in = sizeof(empty_block);
+-                impl.inflate(zs, zlib::Flush::sync, ec);
+-                if(! ec)
+-                {
+-                    // https://github.com/madler/zlib/issues/280
+-                    if(zs.total_out > 0)
+-                        ec = error::partial_deflate_block;
+-                }
+-                if(impl.check_stop_now(ec))
+-                    return bytes_written;
+-                impl.do_context_takeover_read(impl.role);
+-                impl.rd_done = true;
+-                break;
++                fin = true;
+             }
+             else
+             {
+@@ -1232,6 +1223,15 @@
+             impl.inflate(zs, zlib::Flush::sync, ec);
+             if(impl.check_stop_now(ec))
+                 return bytes_written;
++            if (fin) {
++                if (zs.total_out == 0) {
++                    impl.do_context_takeover_read(impl.role);
++                    impl.rd_done = true;
++                    break;
++                } else {
++                    printf("-> partial_deflate_block %lu <-\n", zs.total_out);
++                }
++            }
+             if(impl.rd_msg_max && beast::detail::sum_exceeds(
+                 impl.rd_size, zs.total_out, impl.rd_msg_max))
+             {
+@@ -1241,8 +1241,10 @@
+             }
+             cb.consume(zs.total_out);
+             impl.rd_size += zs.total_out;
+-            impl.rd_remain -= zs.total_in;
+-            impl.rd_buf.consume(zs.total_in);
++            if (!fin) {
++                impl.rd_remain -= zs.total_in;
++                impl.rd_buf.consume(zs.total_in);
++            }
+             bytes_written += zs.total_out;
+         }
+         if(impl.rd_op == detail::opcode::text)

--- a/patches/boost_1_73_0_fix_beast_partial_deflate_block.patch
+++ b/patches/boost_1_73_0_fix_beast_partial_deflate_block.patch
@@ -1,7 +1,5 @@
-Backporting fixes for when a received deflate block spans multiple multi_byte character arrays.
-Reference: https://github.com/boostorg/beast/pull/2191
 --- a/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 15:42:22.000000000 -0700
-+++ b/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 15:49:42.000000000 -0700
++++ b/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 19:33:59.000000000 -0700
 @@ -471,6 +471,7 @@
                          zs.avail_out = out.size();
                          BOOST_ASSERT(zs.avail_out > 0);
@@ -10,7 +8,12 @@ Reference: https://github.com/boostorg/beast/pull/2191
                      if(impl.rd_remain > 0)
                      {
                          if(impl.rd_buf.size() > 0)
-@@ -494,18 +495,7 @@
+@@ -490,22 +491,11 @@
+                     else if(impl.rd_fh.fin)
+                     {
+                         // append the empty block codes
+-                        std::uint8_t constexpr
++                        static std::uint8_t constexpr
                              empty_block[4] = { 0x00, 0x00, 0xff, 0xff };
                          zs.next_in = empty_block;
                          zs.avail_in = sizeof(empty_block);
@@ -30,7 +33,7 @@ Reference: https://github.com/boostorg/beast/pull/2191
                      }
                      else
                      {
-@@ -514,6 +504,15 @@
+@@ -514,6 +504,13 @@
                      impl.inflate(zs, zlib::Flush::sync, ec);
                      if(impl.check_stop_now(ec))
                          goto upcall;
@@ -39,14 +42,12 @@ Reference: https://github.com/boostorg/beast/pull/2191
 +                            impl.do_context_takeover_read(impl.role);
 +                            impl.rd_done = true;
 +                            break;
-+                        } else {
-+                            printf("-> partial_deflate_block %lu <-\n", zs.total_out);
 +                        }
 +                    }
                      if(impl.rd_msg_max && beast::detail::sum_exceeds(
                          impl.rd_size, zs.total_out, impl.rd_msg_max))
                      {
-@@ -524,8 +523,10 @@
+@@ -524,8 +521,10 @@
                      }
                      cb_.consume(zs.total_out);
                      impl.rd_size += zs.total_out;
@@ -59,7 +60,7 @@ Reference: https://github.com/boostorg/beast/pull/2191
                      bytes_written_ += zs.total_out;
                  }
                  if(impl.rd_op == detail::opcode::text)
-@@ -1165,6 +1166,7 @@
+@@ -1165,6 +1164,7 @@
                  zs.avail_out = out.size();
                  BOOST_ASSERT(zs.avail_out > 0);
              }
@@ -67,8 +68,13 @@ Reference: https://github.com/boostorg/beast/pull/2191
              if(impl.rd_remain > 0)
              {
                  if(impl.rd_buf.size() > 0)
-@@ -1212,18 +1214,7 @@
-                         0x00, 0x00, 0xff, 0xff };
+@@ -1208,22 +1208,10 @@
+             {
+                 // append the empty block codes
+                 static std::uint8_t constexpr
+-                    empty_block[4] = {
+-                        0x00, 0x00, 0xff, 0xff };
++                    empty_block[4] = { 0x00, 0x00, 0xff, 0xff };
                  zs.next_in = empty_block;
                  zs.avail_in = sizeof(empty_block);
 -                impl.inflate(zs, zlib::Flush::sync, ec);
@@ -87,7 +93,7 @@ Reference: https://github.com/boostorg/beast/pull/2191
              }
              else
              {
-@@ -1232,6 +1223,15 @@
+@@ -1232,6 +1220,13 @@
              impl.inflate(zs, zlib::Flush::sync, ec);
              if(impl.check_stop_now(ec))
                  return bytes_written;
@@ -96,14 +102,12 @@ Reference: https://github.com/boostorg/beast/pull/2191
 +                    impl.do_context_takeover_read(impl.role);
 +                    impl.rd_done = true;
 +                    break;
-+                } else {
-+                    printf("-> partial_deflate_block %lu <-\n", zs.total_out);
 +                }
 +            }
              if(impl.rd_msg_max && beast::detail::sum_exceeds(
                  impl.rd_size, zs.total_out, impl.rd_msg_max))
              {
-@@ -1241,8 +1241,10 @@
+@@ -1241,8 +1236,10 @@
              }
              cb.consume(zs.total_out);
              impl.rd_size += zs.total_out;

--- a/patches/boost_1_73_0_fix_beast_partial_deflate_block.patch
+++ b/patches/boost_1_73_0_fix_beast_partial_deflate_block.patch
@@ -1,5 +1,8 @@
+Backporting fixes for when a received deflate block spans multiple multi_byte character arrays when inflated.
+Reference: https://github.com/boostorg/beast/pull/2191
+
 --- a/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 15:42:22.000000000 -0700
-+++ b/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-17 19:33:59.000000000 -0700
++++ b/1.73.0/boost/beast/websocket/impl/read.hpp	2021-03-18 14:31:12.000000000 -0700
 @@ -471,6 +471,7 @@
                          zs.avail_out = out.size();
                          BOOST_ASSERT(zs.avail_out > 0);
@@ -37,30 +40,31 @@
                      impl.inflate(zs, zlib::Flush::sync, ec);
                      if(impl.check_stop_now(ec))
                          goto upcall;
-+                    if (fin) {
-+                        if (zs.total_out == 0) {
++                    if(fin)
++                        if(zs.total_out == 0)
++                        {
 +                            impl.do_context_takeover_read(impl.role);
 +                            impl.rd_done = true;
 +                            break;
 +                        }
-+                    }
                      if(impl.rd_msg_max && beast::detail::sum_exceeds(
                          impl.rd_size, zs.total_out, impl.rd_msg_max))
                      {
-@@ -524,8 +521,10 @@
+@@ -524,8 +521,11 @@
                      }
                      cb_.consume(zs.total_out);
                      impl.rd_size += zs.total_out;
 -                    impl.rd_remain -= zs.total_in;
 -                    impl.rd_buf.consume(zs.total_in);
-+                    if (!fin) {
++                    if(! fin)
++                    {
 +                        impl.rd_remain -= zs.total_in;
 +                        impl.rd_buf.consume(zs.total_in);
 +                    }
                      bytes_written_ += zs.total_out;
                  }
                  if(impl.rd_op == detail::opcode::text)
-@@ -1165,6 +1164,7 @@
+@@ -1165,6 +1165,7 @@
                  zs.avail_out = out.size();
                  BOOST_ASSERT(zs.avail_out > 0);
              }
@@ -68,7 +72,7 @@
              if(impl.rd_remain > 0)
              {
                  if(impl.rd_buf.size() > 0)
-@@ -1208,22 +1208,10 @@
+@@ -1208,22 +1209,10 @@
              {
                  // append the empty block codes
                  static std::uint8_t constexpr
@@ -93,27 +97,28 @@
              }
              else
              {
-@@ -1232,6 +1220,13 @@
+@@ -1232,6 +1221,13 @@
              impl.inflate(zs, zlib::Flush::sync, ec);
              if(impl.check_stop_now(ec))
                  return bytes_written;
-+            if (fin) {
-+                if (zs.total_out == 0) {
++            if(fin)
++                if(zs.total_out == 0)
++                {
 +                    impl.do_context_takeover_read(impl.role);
 +                    impl.rd_done = true;
 +                    break;
 +                }
-+            }
              if(impl.rd_msg_max && beast::detail::sum_exceeds(
                  impl.rd_size, zs.total_out, impl.rd_msg_max))
              {
-@@ -1241,8 +1236,10 @@
+@@ -1241,8 +1237,11 @@
              }
              cb.consume(zs.total_out);
              impl.rd_size += zs.total_out;
 -            impl.rd_remain -= zs.total_in;
 -            impl.rd_buf.consume(zs.total_in);
-+            if (!fin) {
++            if(! fin)
++            {
 +                impl.rd_remain -= zs.total_in;
 +                impl.rd_buf.consume(zs.total_in);
 +            }


### PR DESCRIPTION
backport fixes for `patial_deflate_block` when deflate block actually spans multiple `multi_buffer` arrays.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
