### PR TITLE
VIDEO-4730: Publish artifacts to Artifactory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,9 +201,9 @@ jobs:
             - prepare_macos_ios:
                 cache-tag: xcode12
 
-  deploy-bintray:
+  deploy-artifactory:
     executor: linux-executor
-    description: "Deploy binaries to bintray"
+    description: "Deploy binaries to artifactory"
     parameters:
       <<: *boost-libs-parameter
     steps:
@@ -213,9 +213,9 @@ jobs:
       - generate_build_settings
       - run: #generate_maven_settings
           name: Generate Maven settings
-          command: echo "$BINTRAY_SETTINGS" | base64 --decode > bintray-settings.xml
+          command: echo "$ARTIFACTORY_SETTINGS" | base64 --decode > artifactory-settings.xml
       - run:
-          name: Deploy binaries to bintray
+          name: Deploy binaries to artifactory
           command: |
             source $BASH_ENV
             ./boost.sh --no-clean --no-unpack --no-framework --deploy `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
@@ -259,7 +259,7 @@ workflows:
           name: build-boost-osx
           requires:
             - unpack
-      - deploy-bintray:
+      - deploy-artifactory:
           <<: *only-release-tags
           name: deploy
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ workflows:
           requires:
             - unpack
       - deploy-artifactory:
-          <<: *only-release-tags
+          <<: *ignore-master
           name: deploy
           requires:
             - build-boost-headers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ workflows:
           requires:
             - unpack
       - deploy-artifactory:
-          <<: *ignore-master
+          <<: *only-release-tags
           name: deploy
           requires:
             - build-boost-headers

--- a/boost.sh
+++ b/boost.sh
@@ -501,7 +501,7 @@ unpackBoost()
     echo Unpacking boost into "$SRCDIR"...
 
     [ -d $SRCDIR ]    || mkdir -p "$SRCDIR"
-    [ -d $BOOST_SRC ] || ( mkdir -p "$BOOST_SRC"; tar xfj "$BOOST_TARBALL" --strip-components 1 -C "$BOOST_SRC") || exit 1
+    [ -d $BOOST_SRC ] || ( mkdir -p "$BOOST_SRC"; tar xfz "$BOOST_TARBALL" --strip-components 1 -C "$BOOST_SRC") || exit 1
     echo "    ...unpacked as $BOOST_SRC"
 
     changeNamespace

--- a/boost.sh
+++ b/boost.sh
@@ -49,10 +49,8 @@ ASYNC_COMMIT=94fe4433287df569ce1aa384b248793552980711
 
 TWILIO_SUFFIX=
 
-BINTRAY_API_URL=https://api.bintray.com
-REPO_URL_FRAGMENT=twilio/releases/rtd-cpp-boost-lib
-REPO_URL="${BINTRAY_API_URL}/maven/${REPO_URL_FRAGMENT}/;publish=0"
-REPO_ID=bintray
+REPO_URL="https://twilio.jfrog.io/artifactory/releases/"
+REPO_ID=artifactory
 
 MIN_IOS_VERSION=9.0
 
@@ -157,7 +155,7 @@ OPTIONS:
         Do not download or unpack anything. Use local unpacked copy.
 
     --deploy
-        Only send request to bintray to mark packages published. Do nothing else.
+        Only send request to artifactory to mark packages published. Do nothing else.
 
     --boost-version [num]
         Specify which version of Boost to build. Defaults to $BOOST_VERSION.
@@ -1232,14 +1230,14 @@ deployPlat()
     done
 }
 
-deployToBintray()
+deployToArtifactory()
 {
     if [[ -z "$REPO_ID" ]]; then
         abort "Specify REPO_ID to deploy"
     fi
 
     BUILDDIR="$CURRENT_DIR/target/distributions"
-    SETTINGS_FILE="-s $CURRENT_DIR/bintray-settings.xml"
+    SETTINGS_FILE="-s $CURRENT_DIR/artifactory-settings.xml"
     deployFile boost-headers "${BUILDDIR}/boost-headers-${BOOST_VERSION}${TWILIO_SUFFIX}-all.tar.bz2" all ${BOOST_VERSION}${TWILIO_SUFFIX}
     deployPlat "android" "$BUILDDIR"
     deployPlat "ios" "$BUILDDIR"
@@ -1669,7 +1667,7 @@ if [[ -n $BUILD_IOS || -n $BUILD_TVOS || -n $BUILD_OSX || -n $BUILD_ANDROID \
 fi
 
 if [[ -n "$DEPLOY" ]]; then
-    deployToBintray
+    deployToArtifactory
 fi
 
 echo "Completed successfully"

--- a/boost.sh
+++ b/boost.sh
@@ -47,7 +47,7 @@ DEPLOY=
 
 ASYNC_COMMIT=94fe4433287df569ce1aa384b248793552980711
 
-TWILIO_SUFFIX=
+TWILIO_SUFFIX=99
 
 REPO_URL="https://twilio.jfrog.io/artifactory/releases/"
 REPO_ID=artifactory

--- a/boost.sh
+++ b/boost.sh
@@ -21,7 +21,7 @@
 #    OSX_SDK_VERSION: OSX SDK version (e.g. 10.11)
 #    MIN_OSX_VERSION: Minimum OS X Target Version (e.g. 10.10)
 #
-# If a boost tarball (a file named “boost_$BOOST_VERSION2.tar.gz”) does not
+# If a boost tarball (a file named “boost_$BOOST_VERSION2.tar.bz2”) does not
 # exist in the current directory, this script will attempt to download the
 # version specified by BOOST_VERSION2. You may also manually place a matching 
 # tarball in the current directory and the script will use that.
@@ -259,7 +259,7 @@ parseArgs()
                     BOOST_VERSION=$2
                     BOOST_VERSION2="${BOOST_VERSION/beta./b}"
                     BOOST_VERSION2="${BOOST_VERSION2//./_}"
-                    BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.gz"
+                    BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.bz2"
                     BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"
                     shift
                 else
@@ -451,7 +451,7 @@ downloadBoost()
     mkdir -p "$(dirname $BOOST_TARBALL)"
 
     if [ ! -s $BOOST_TARBALL ]; then
-        URL=https://github.com/boostorg/boost/archive/refs/tags/boost-${BOOST_VERSION}.tar.gz
+        URL=https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
         echo "Downloading boost ${BOOST_VERSION} from $URL"
         curl -L -o "$BOOST_TARBALL" $URL
         doneSection
@@ -501,7 +501,7 @@ unpackBoost()
     echo Unpacking boost into "$SRCDIR"...
 
     [ -d $SRCDIR ]    || mkdir -p "$SRCDIR"
-    [ -d $BOOST_SRC ] || ( mkdir -p "$BOOST_SRC"; tar xfz "$BOOST_TARBALL" --strip-components 1 -C "$BOOST_SRC") || exit 1
+    [ -d $BOOST_SRC ] || ( mkdir -p "$BOOST_SRC"; tar xfj "$BOOST_TARBALL" --strip-components 1 -C "$BOOST_SRC") || exit 1
     echo "    ...unpacked as $BOOST_SRC"
 
     changeNamespace
@@ -1518,7 +1518,7 @@ if [[ -z $BOOST_VERSION ]]; then
     BOOST_VERSION=`curl -s 'https://github.com/boostorg/boost/releases' | grep -o "\/boostorg\/boost\/releases\/tag\/boost-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\"" | cut -d"-" -f2 | cut -d"\"" -f1 | head -1`
     echo "Detecting the latest boost version from https://github.com/boostorg/boost/releases to be version $BOOST_VERSION"
     BOOST_VERSION2="${BOOST_VERSION//./_}"
-    BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.gz"
+    BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.bz2"
     BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"
 fi
 
@@ -1572,7 +1572,7 @@ else
    EXTRA_LINUX_FLAGS="$EXTRA_FLAGS"
 fi
 
-BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.gz"
+BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.bz2"
 BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"
 OUTPUT_DIR="$CURRENT_DIR/target/outputs/boost/$BOOST_VERSION/$BOOST_PLATFORM"
 BUILD_DIR="$OUTPUT_DIR/build"

--- a/boost.sh
+++ b/boost.sh
@@ -259,7 +259,7 @@ parseArgs()
                     BOOST_VERSION=$2
                     BOOST_VERSION2="${BOOST_VERSION/beta./b}"
                     BOOST_VERSION2="${BOOST_VERSION2//./_}"
-                    BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.bz2"
+                    BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.gz"
                     BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"
                     shift
                 else
@@ -451,7 +451,7 @@ downloadBoost()
     mkdir -p "$(dirname $BOOST_TARBALL)"
 
     if [ ! -s $BOOST_TARBALL ]; then
-        URL=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
+        URL=https://github.com/boostorg/boost/archive/refs/tags/boost-${BOOST_VERSION}.tar.gz
         echo "Downloading boost ${BOOST_VERSION} from $URL"
         curl -L -o "$BOOST_TARBALL" $URL
         doneSection
@@ -1515,8 +1515,8 @@ EOF
 parseArgs "$@"
 
 if [[ -z $BOOST_VERSION ]]; then
-    BOOST_VERSION=`curl -s 'https://www.boost.org' | sed -n 's/.*https:\/\/dl\.bintray\.com\/boostorg\/release\/\([^\/]*\)\/.*$/\1/p'`
-    echo "Detecting the latest boost version from https://www.boost.org to be version $BOOST_VERSION"
+    BOOST_VERSION=`curl -s 'https://github.com/boostorg/boost/releases' | grep -o "\/boostorg\/boost\/releases\/tag\/boost-\(\d\+\.\d\+\.\d\+\)\"" | cut -d"-" -f2 | cut -d"\"" -f1 | head -1`
+    echo "Detecting the latest boost version from https://github.com/boostorg/boost/releases to be version $BOOST_VERSION"
     BOOST_VERSION2="${BOOST_VERSION//./_}"
     BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.bz2"
     BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"

--- a/boost.sh
+++ b/boost.sh
@@ -1515,7 +1515,7 @@ EOF
 parseArgs "$@"
 
 if [[ -z $BOOST_VERSION ]]; then
-    BOOST_VERSION=`curl -s 'https://github.com/boostorg/boost/releases' | grep -o "\/boostorg\/boost\/releases\/tag\/boost-\(\d\+\.\d\+\.\d\+\)\"" | cut -d"-" -f2 | cut -d"\"" -f1 | head -1`
+    BOOST_VERSION=`curl -s 'https://github.com/boostorg/boost/releases' | grep -o "\/boostorg\/boost\/releases\/tag\/boost-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\"" | cut -d"-" -f2 | cut -d"\"" -f1 | head -1`
     echo "Detecting the latest boost version from https://github.com/boostorg/boost/releases to be version $BOOST_VERSION"
     BOOST_VERSION2="${BOOST_VERSION//./_}"
     BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.gz"

--- a/boost.sh
+++ b/boost.sh
@@ -47,7 +47,7 @@ DEPLOY=
 
 ASYNC_COMMIT=94fe4433287df569ce1aa384b248793552980711
 
-TWILIO_SUFFIX=99
+TWILIO_SUFFIX=
 
 REPO_URL="https://twilio.jfrog.io/artifactory/releases/"
 REPO_ID=artifactory

--- a/boost.sh
+++ b/boost.sh
@@ -21,7 +21,7 @@
 #    OSX_SDK_VERSION: OSX SDK version (e.g. 10.11)
 #    MIN_OSX_VERSION: Minimum OS X Target Version (e.g. 10.10)
 #
-# If a boost tarball (a file named “boost_$BOOST_VERSION2.tar.bz2”) does not
+# If a boost tarball (a file named “boost_$BOOST_VERSION2.tar.gz”) does not
 # exist in the current directory, this script will attempt to download the
 # version specified by BOOST_VERSION2. You may also manually place a matching 
 # tarball in the current directory and the script will use that.
@@ -1518,7 +1518,7 @@ if [[ -z $BOOST_VERSION ]]; then
     BOOST_VERSION=`curl -s 'https://github.com/boostorg/boost/releases' | grep -o "\/boostorg\/boost\/releases\/tag\/boost-\(\d\+\.\d\+\.\d\+\)\"" | cut -d"-" -f2 | cut -d"\"" -f1 | head -1`
     echo "Detecting the latest boost version from https://github.com/boostorg/boost/releases to be version $BOOST_VERSION"
     BOOST_VERSION2="${BOOST_VERSION//./_}"
-    BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.bz2"
+    BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.gz"
     BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"
 fi
 
@@ -1572,7 +1572,7 @@ else
    EXTRA_LINUX_FLAGS="$EXTRA_FLAGS"
 fi
 
-BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.bz2"
+BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.gz"
 BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"
 OUTPUT_DIR="$CURRENT_DIR/target/outputs/boost/$BOOST_VERSION/$BOOST_PLATFORM"
 BUILD_DIR="$OUTPUT_DIR/build"


### PR DESCRIPTION
With the looming shutdown of Bintray on the horizon we will now publish our artifacts to our Artifactory instance instead.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
