### PR TITLE
VIDEO-8190: Update toolchain image and fix boost builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
               echo "Will attempt to build with the latest boost version."
             else
               BOOST_VERSION=$(echo $CIRCLE_TAG | cut -d - -f 2)
-              if [[ "$BOOST_VERSION" == "" ]; then
+              if [[ "$BOOST_VERSION" == "" ]]; then
                 echo "Failed to parse boost version from tag: $CIRCLE_TAG"
                 echo "Expected format: \`release-1.71.0-twilio3\`"
                 exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ executors:
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_PASSWORD
-    resource_class: xlarge
+    resource_class: medium+
     working_directory: *workspace
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
@@ -93,9 +93,9 @@ commands:
         description: "Cache tag"
         type: string
     steps:
-      - restore_cache:
-          keys:
-            - v4-homebrew-<< parameters.cache-tag >>-{{ checksum ".circleci/config.yml" }}
+#      - restore_cache:
+#          keys:
+#            - v4-homebrew-<< parameters.cache-tag >>-{{ checksum ".circleci/config.yml" }}
       - run:
           name: "Install necessary components through Homebrew"
           command: |
@@ -103,10 +103,10 @@ commands:
             brew install maven
             brew install boost-bcp
             brew install rsync
-      - save_cache:
-          key: v4-homebrew-<< parameters.cache-tag >>-{{ checksum ".circleci/config.yml" }}
-          paths:
-            - /usr/local/Homebrew
+#      - save_cache:
+#          key: v4-homebrew-<< parameters.cache-tag >>-{{ checksum ".circleci/config.yml" }}
+#          paths:
+#            - /usr/local/Homebrew
 
   unpack:
     description: "Unpack boost tarball"
@@ -151,15 +151,21 @@ commands:
 
 jobs:
   unpack-sources:
-    executor: linux-executor
+    executor:
+      name: linux-executor
+      resource_class: small
     steps:
       - run:
           name: apt install
-          command: apt -y --no-install-recommends install libboost-tools-dev rsync
+          command: |
+            apt-get -y update
+            apt-get -y --no-install-recommends install libboost-tools-dev
       - unpack
 
   build-headers:
-    executor: linux-executor
+    executor:
+      name: linux-executor
+      resource_class: small
     steps:
       - build:
           platform: headers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,12 @@
 version: 2.1
 
 parameters:
+  boost-libs:
+    description: "List of boost libraries to build"
+    type: string
+    # We removed serialization as we need to be able to build for iOS 9 and there are code that is using iOS 10+ features
+    default: "atomic context coroutine date_time exception iostreams program_options random regex system test thread"
+
   xcode-version:
     description: Xcode version for iOS and Darwin builds
     type: string
@@ -29,36 +35,6 @@ aliases:
         branches:
           ignore: /.*/
 
-  - platform-parameter: &platform-parameter
-      platform:
-        description: "Platform to build"
-        type: enum
-        enum: ["headers", "android", "linux", "linux-cxx11-abi-disabled", "ios", "osx"]
-
-  - boost-libs-parameter: &boost-libs-parameter
-      boost-libs:
-        description: "List of boost libraries to build"
-        type: string
-        # We removed serialization as we need to be able to build for iOS 9 and there are code that is using iOS 10+ features
-        default: "atomic context coroutine date_time exception iostreams program_options random regex system test thread"
-
-  - pre-steps-parameter: &pre-steps-parameter
-      pre-steps:
-        description: "Steps that will be executed before build starts"
-        type: steps
-        default: []
-
-  - post-steps-parameter: &post-steps-parameter
-      post-steps:
-        description: "Steps that will be executed after build ends"
-        type: steps
-        default: []
-
-  - build-steps-parameter: &build-steps-parameter
-      build-steps:
-        description: "Steps that will be executed as main build target"
-        type: steps
-
 executors:
   linux-executor:
     parameters:
@@ -84,29 +60,37 @@ executors:
 
 commands:
   generate_build_settings:
-    description: "Generate build env variables"
+    description: "Parse tag to determine boost version and twilio suffix"
     steps:
       - run:
-          name: Make env variables from build tag
+          name: Parse build tag
           command: |
             if [ -z "$CIRCLE_TAG" ]; then
               echo "Must use release tag to build boost releases. Push \`release-1.71.0-twilio3\`-style tag to trigger."
-              touch $BASH_ENV
+              echo "Will attempt to build with the latest boost version."
             else
-              echo 'export BOOST_VERSION=$(echo $CIRCLE_TAG | cut -d - -f 2)' >> $BASH_ENV
-              echo 'export TWILIO_SUFFIX=$(echo $CIRCLE_TAG | cut -d - -f 3)' >> $BASH_ENV
+              BOOST_VERSION=$(echo $CIRCLE_TAG | cut -d - -f 2)
+              if [[ "$BOOST_VERSION" == "" ]; then
+                echo "Failed to parse boost version from tag: $CIRCLE_TAG"
+                echo "Expected format: \`release-1.71.0-twilio3\`"
+                exit 1
+              fi
+              echo BOOST_VERSION=$BOOST_VERSION
+
+              TWILIO_SUFFIX=$(echo $CIRCLE_TAG | cut -d - -f 3)
+              echo TWILIO_SUFFIX=$TWILIO_SUFFIX
+
+              echo "export BOOST_VERSION=$BOOST_VERSION" >> $BASH_ENV
+              echo "export TWILIO_SUFFIX=$TWILIO_SUFFIX" >> $BASH_ENV
             fi
 
-  prepare_macos_ios:
+  install_mac_buildtools:
     description: "Prepare environment for MacOS and iOS builds"
     steps:
       - run:
-          name: "Install necessary components through Homebrew"
+          name: "Run brew install"
           command: |
-            brew update
-            brew install maven
-            brew install boost-bcp
-            brew install rsync
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install maven boost-bcp rsync
 
   unpack:
     description: "Unpack boost tarball"
@@ -116,7 +100,9 @@ commands:
       - run:
           name: Unpack tarball
           command: |
-            source $BASH_ENV
+            echo BOOST_VERSION=$BOOST_VERSION
+            echo TWILIO_SUFFIX=$TWILIO_SUFFIX
+
             ./boost.sh --unpack `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
               `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX`
           no_output_timeout: 120m
@@ -128,19 +114,23 @@ commands:
   build:
     description: "Build and Publish"
     parameters:
-      <<: [*platform-parameter, *boost-libs-parameter, *pre-steps-parameter]
+      platform:
+        description: "Platform to build"
+        type: enum
+        enum: [ headers, android, linux, linux-cxx11-abi-disabled, ios, osx ]
     steps:
       - checkout
-      - steps: << parameters.pre-steps >>
       - attach_workspace:
           at: *workspace
       - generate_build_settings
       - run:
           name: Build << parameters.platform >>
           command: |
-            source $BASH_ENV
+            echo BOOST_VERSION=$BOOST_VERSION
+            echo TWILIO_SUFFIX=$TWILIO_SUFFIX
+
             ./boost.sh -<< parameters.platform >> --no-clean --no-unpack --no-framework `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
-              `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< parameters.boost-libs >>"
+              `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< pipeline.parameters.boost-libs >>"
           no_output_timeout: 120m
       - persist_to_workspace:
           root: .
@@ -181,18 +171,15 @@ jobs:
         enum: [ osx, ios ]
     executor: mac-executor
     steps:
+      - install_mac_buildtools
       - build:
           platform: << parameters.platform >>
-          pre-steps:
-            - prepare_macos_ios
 
   deploy-artifactory:
     description: "Deploy binaries to artifactory"
     executor:
       name: linux-executor
       resource-class: small
-    parameters:
-      <<: *boost-libs-parameter
     steps:
       - checkout
       - attach_workspace:
@@ -207,7 +194,7 @@ jobs:
           command: |
             source $BASH_ENV
             ./boost.sh --no-clean --no-unpack --no-framework --deploy `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
-              `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< parameters.boost-libs >>"
+              `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< pipeline.parameters.boost-libs >>"
 
 workflows:
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 version: 2.1
 
+parameters:
+  twilio-video-sdk-toolchain-image:
+    description: twilio-video-sdk-toolchain docker image to use for linux and android
+    type: string
+    default: "twilio/twilio-video-sdk-toolchain:edb23a0c29310a9f56aad430bfebd8bea232e11d"
+
 aliases:
   - &workspace
     ~/twilio-boost-build
@@ -56,7 +62,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   android-executor:
     docker:
-      - image: twilio/twilio-video-sdk-toolchain:1da717d4f4403cb9b68169fe2256b6d1b2c93694
+      - image: << pipeline.parameters.twilio-video-sdk-toolchain-image >>
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,41 +14,46 @@ parameters:
 aliases:
   - &workspace
     ~/twilio-boost-build
-  - &build_output
-    ~/twilio-boost-build/target/output
+
   - ignore-master: &ignore-master
       filters:
         tags:
           only: /.*/
         branches:
           ignore: /^master/
+
   - only-release-tags: &only-release-tags
       filters:
         tags:
           only: /^release-.*/
         branches:
           ignore: /.*/
+
   - platform-parameter: &platform-parameter
       platform:
         description: "Platform to build"
         type: enum
         enum: ["headers", "android", "linux", "linux-cxx11-abi-disabled", "ios", "osx"]
+
   - boost-libs-parameter: &boost-libs-parameter
       boost-libs:
         description: "List of boost libraries to build"
         type: string
         # We removed serialization as we need to be able to build for iOS 9 and there are code that is using iOS 10+ features
         default: "atomic context coroutine date_time exception iostreams program_options random regex system test thread"
+
   - pre-steps-parameter: &pre-steps-parameter
       pre-steps:
         description: "Steps that will be executed before build starts"
         type: steps
         default: []
+
   - post-steps-parameter: &post-steps-parameter
       post-steps:
         description: "Steps that will be executed after build ends"
         type: steps
         default: []
+
   - build-steps-parameter: &build-steps-parameter
       build-steps:
         description: "Steps that will be executed as main build target"
@@ -70,6 +75,7 @@ executors:
     working_directory: *workspace
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
+
   mac-executor:
     macos:
       xcode: << pipeline.parameters.xcode-version >>
@@ -92,15 +98,8 @@ commands:
             fi
 
   prepare_macos_ios:
-    description: "Prepare environment for MacOS and iOS builds (cache enabled)"
-    parameters:
-      cache-tag:
-        description: "Cache tag"
-        type: string
+    description: "Prepare environment for MacOS and iOS builds"
     steps:
-#      - restore_cache:
-#          keys:
-#            - v4-homebrew-<< parameters.cache-tag >>-{{ checksum ".circleci/config.yml" }}
       - run:
           name: "Install necessary components through Homebrew"
           command: |
@@ -108,10 +107,6 @@ commands:
             brew install maven
             brew install boost-bcp
             brew install rsync
-#      - save_cache:
-#          key: v4-homebrew-<< parameters.cache-tag >>-{{ checksum ".circleci/config.yml" }}
-#          paths:
-#            - /usr/local/Homebrew
 
   unpack:
     description: "Unpack boost tarball"
@@ -167,61 +162,35 @@ jobs:
             apt-get -y --no-install-recommends install libboost-tools-dev
       - unpack
 
-  build-headers:
+  build-on-linux:
+    parameters:
+      platform:
+        type: enum
+        enum: [ headers, linux, linux-cxx11-abi-disabled, android ]
+    executor:
+      name: linux-executor
+      resource-class: medium+
+    steps:
+      - build:
+          platform: << parameters.platform >>
+
+  build-on-mac:
+    parameters:
+      platform:
+        type: enum
+        enum: [ osx, ios ]
+    executor: mac-executor
+    steps:
+      - build:
+          platform: << parameters.platform >>
+          pre-steps:
+            - prepare_macos_ios
+
+  deploy-artifactory:
+    description: "Deploy binaries to artifactory"
     executor:
       name: linux-executor
       resource-class: small
-    steps:
-      - build:
-          platform: headers
-      - store_artifacts:
-          path: /root/twilio-boost-build/target/outputs/boost
-
-  build-linux:
-    executor: linux-executor
-    steps:
-      - build:
-          platform: linux
-      - store_artifacts:
-          path: /root/twilio-boost-build/target/outputs/boost
-
-  build-linux-cxx11-abi-disabled:
-    executor: linux-executor
-    steps:
-      - build:
-          platform: linux-cxx11-abi-disabled
-      - store_artifacts:
-          path: /root/twilio-boost-build/target/outputs/boost
-
-  build-android:
-    executor: linux-executor
-    steps:
-      - build:
-          platform: android
-      - store_artifacts:
-          path: /root/twilio-boost-build/target/outputs/boost
-
-  build-osx:
-    executor: mac-executor
-    steps:
-      - build:
-          platform: osx
-          pre-steps:
-            - prepare_macos_ios:
-                cache-tag: << pipeline.parameters.xcode-version >>
-
-  build-ios:
-    executor: mac-executor
-    steps:
-      - build:
-          platform: ios
-          pre-steps:
-            - prepare_macos_ios:
-                cache-tag: << pipeline.parameters.xcode-version >>
-
-  deploy-artifactory:
-    executor: linux-executor
-    description: "Deploy binaries to artifactory"
     parameters:
       <<: *boost-libs-parameter
     steps:
@@ -241,55 +210,36 @@ jobs:
               `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< parameters.boost-libs >>"
 
 workflows:
-  version: 2
   build-and-deploy:
     jobs:
       - unpack-sources:
           <<: *ignore-master
           name: unpack
           context: dockerhub-pulls
-      - build-headers:
+
+      - build-on-linux:
           <<: *ignore-master
-          name: build-boost-headers
+          name: build-boost-<< matrix.platform >>
           context: dockerhub-pulls
           requires:
             - unpack
-      - build-android:
+          matrix:
+            parameters:
+              platform: [ headers, linux, linux-cxx11-abi-disabled, android ]
+
+      - build-on-mac:
           <<: *ignore-master
-          name: build-boost-android
-          context: dockerhub-pulls
+          name: build-boost-<< matrix.platform >>
           requires:
             - unpack
-      - build-linux:
-          <<: *ignore-master
-          name: build-boost-linux
-          context: dockerhub-pulls
-          requires:
-            - unpack
-      - build-linux-cxx11-abi-disabled:
-          <<: *ignore-master
-          name: build-boost-linux-cxx11-abi-disabled
-          context: dockerhub-pulls
-          requires:
-            - unpack
-      - build-ios:
-          <<: *ignore-master
-          name: build-boost-ios
-          requires:
-            - unpack
-      - build-osx:
-          <<: *ignore-master
-          name: build-boost-osx
-          requires:
-            - unpack
+          matrix:
+            parameters:
+              platform: [ ios, osx ]
+
       - deploy-artifactory:
           <<: *only-release-tags
           name: deploy
           context: dockerhub-pulls
           requires:
-            - build-boost-headers
-            - build-boost-android
-            - build-boost-linux
-            - build-boost-linux-cxx11-abi-disabled
-            - build-boost-ios
-            - build-boost-osx
+            - build-on-linux
+            - build-on-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,24 +175,32 @@ jobs:
     steps:
       - build:
           platform: headers
+      - store_artifacts:
+          path: /root/twilio-boost-build/target/outputs/boost
 
   build-linux:
     executor: linux-executor
     steps:
       - build:
           platform: linux
+      - store_artifacts:
+          path: /root/twilio-boost-build/target/outputs/boost
 
   build-linux-cxx11-abi-disabled:
     executor: linux-executor
     steps:
       - build:
           platform: linux-cxx11-abi-disabled
+      - store_artifacts:
+          path: /root/twilio-boost-build/target/outputs/boost
 
   build-android:
     executor: android-executor
     steps:
       - build:
           platform: android
+      - store_artifacts:
+          path: /root/twilio-boost-build/target/outputs/boost
 
   build-osx:
     executor: macos-ios-executor
@@ -227,11 +235,11 @@ jobs:
           command: echo "$ARTIFACTORY_SETTINGS" | base64 --decode > artifactory-settings.xml
       - run:
           name: Deploy binaries to artifactory
+          no_output_timeout: 120m
           command: |
             source $BASH_ENV
             ./boost.sh --no-clean --no-unpack --no-framework --deploy `test -n "${BOOST_VERSION:-}" && echo --boost-version $BOOST_VERSION` \
               `test -n "${TWILIO_SUFFIX:-}" && echo --twilio-suffix -$TWILIO_SUFFIX` --boost-libs "<< parameters.boost-libs >>"
-          no_output_timeout: 120m
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
   twilio-video-sdk-toolchain-image:
     description: twilio-video-sdk-toolchain docker image to use for linux and android
     type: string
-    default: "twilio/twilio-video-sdk-toolchain:edb23a0c29310a9f56aad430bfebd8bea232e11d"
+    default: "twilio/twilio-video-sdk-toolchain:17"
 
 aliases:
   - &workspace
@@ -57,16 +57,6 @@ aliases:
 executors:
   linux-executor:
     docker:
-      - image: cibuilderbot/docker-circleci-linux-android
-        auth:
-          username: $DOCKER_HUB_USERNAME
-          password: $DOCKER_HUB_PASSWORD
-    resource_class: xlarge
-    working_directory: *workspace
-    environment:
-      CMAKE_BUILD_PARALLEL_LEVEL: 2
-  android-executor:
-    docker:
       - image: << pipeline.parameters.twilio-video-sdk-toolchain-image >>
         auth:
           username: $DOCKER_HUB_USERNAME
@@ -75,10 +65,10 @@ executors:
     working_directory: *workspace
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
-  macos-ios-executor:
+  mac-executor:
     macos:
       xcode: << pipeline.parameters.xcode-version >>
-    resource_class: large
+    resource_class: macos.x86.medium.gen2
     working_directory: *workspace
 
 commands:
@@ -138,9 +128,7 @@ commands:
   build:
     description: "Build and Publish"
     parameters:
-      <<: *platform-parameter
-      <<: *boost-libs-parameter
-      <<: *pre-steps-parameter
+      <<: [*platform-parameter, *boost-libs-parameter, *pre-steps-parameter]
     steps:
       - checkout
       - steps: << parameters.pre-steps >>
@@ -195,7 +183,7 @@ jobs:
           path: /root/twilio-boost-build/target/outputs/boost
 
   build-android:
-    executor: android-executor
+    executor: linux-executor
     steps:
       - build:
           platform: android
@@ -203,7 +191,7 @@ jobs:
           path: /root/twilio-boost-build/target/outputs/boost
 
   build-osx:
-    executor: macos-ios-executor
+    executor: mac-executor
     steps:
       - build:
           platform: osx
@@ -212,7 +200,7 @@ jobs:
                 cache-tag: << pipeline.parameters.xcode-version >>
 
   build-ios:
-    executor: macos-ios-executor
+    executor: mac-executor
     steps:
       - build:
           platform: ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   android-executor:
     docker:
-      - image: twilio/twilio-video-sdk-toolchain:16
+      - image: twilio/twilio-video-sdk-toolchain:1da717d4f4403cb9b68169fe2256b6d1b2c93694
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,11 @@
 version: 2.1
 
 parameters:
+  xcode-version:
+    description: Xcode version for iOS and Darwin builds
+    type: string
+    default: "12.5.1"
+
   twilio-video-sdk-toolchain-image:
     description: twilio-video-sdk-toolchain docker image to use for linux and android
     type: string
@@ -72,7 +77,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   macos-ios-executor:
     macos:
-      xcode: "12.2.0"
+      xcode: << pipeline.parameters.xcode-version >>
     resource_class: large
     working_directory: *workspace
 
@@ -196,7 +201,7 @@ jobs:
           platform: osx
           pre-steps:
             - prepare_macos_ios:
-                cache-tag: xcode12
+                cache-tag: << pipeline.parameters.xcode-version >>
 
   build-ios:
     executor: macos-ios-executor
@@ -205,7 +210,7 @@ jobs:
           platform: ios
           pre-steps:
             - prepare_macos_ios:
-                cache-tag: xcode12
+                cache-tag: << pipeline.parameters.xcode-version >>
 
   deploy-artifactory:
     executor: linux-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,12 +56,17 @@ aliases:
 
 executors:
   linux-executor:
+    parameters:
+      resource-class:
+        type: enum
+        enum: [small, medium, medium+, large, xlarge]
+        default: medium+
     docker:
       - image: << pipeline.parameters.twilio-video-sdk-toolchain-image >>
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_PASSWORD
-    resource_class: medium+
+    resource_class: << parameters.resource-class >>
     working_directory: *workspace
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
@@ -153,7 +158,7 @@ jobs:
   unpack-sources:
     executor:
       name: linux-executor
-      resource_class: small
+      resource-class: small
     steps:
       - run:
           name: apt install
@@ -165,7 +170,7 @@ jobs:
   build-headers:
     executor:
       name: linux-executor
-      resource_class: small
+      resource-class: small
     steps:
       - build:
           platform: headers

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 target/
 src/
+.idea/

--- a/boost.sh
+++ b/boost.sh
@@ -1513,8 +1513,12 @@ EOF
 parseArgs "$@"
 
 if [[ -z $BOOST_VERSION ]]; then
-    BOOST_VERSION=`curl -s 'https://github.com/boostorg/boost/releases' | grep -o "\/boostorg\/boost\/releases\/tag\/boost-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\"" | cut -d"-" -f2 | cut -d"\"" -f1 | head -1`
-    echo "Detecting the latest boost version from https://github.com/boostorg/boost/releases to be version $BOOST_VERSION"
+    BOOST_VERSION=`curl -s 'https://github.com/boostorg/boost/tags' | grep -o "boost-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\"" | cut -d"-" -f2 | cut -d"\"" -f1 | head -1`
+    if [[ "$BOOST_VERSION" == "" ]]; then
+      echo "Failed to determine latest boost version from https://github.com/boostorg/boost/tags"
+      exit 1
+    fi
+    echo "Detected the latest boost version from https://github.com/boostorg/boost/tags to be version $BOOST_VERSION"
     BOOST_VERSION2="${BOOST_VERSION//./_}"
     BOOST_TARBALL="$CURRENT_DIR/src/boost_$BOOST_VERSION2.tar.bz2"
     BOOST_SRC="$SRCDIR/boost/${BOOST_VERSION}"

--- a/boost.sh
+++ b/boost.sh
@@ -724,24 +724,6 @@ using gcc : : g++ $LINUX_ARCH_FLAGS $EXTRA_LINUX_FLAGS
 <compileflags>-Wall
 <compileflags>-Wshadow
 ;
-using gcc : 8.3.0~arm
-: arm-linux-gnueabihf-g++ $LINUX_ARCH_FLAGS $EXTRA_LINUX_FLAGS
-:
-<architecture>arm <target-os>linux
-<compileflags>-isystem <compileflags>/usr/include/arm-linux-gnueabihf/
-<compileflags>-ffunction-sections
-<compileflags>-fPIC
-<compileflags>-fno-omit-frame-pointer
-<compileflags>-march=armv7-a
-<compileflags>-mfloat-abi=hard
-<compileflags>-mtune=generic-armv7-a
-<compileflags>-mfpu=neon
-<compileflags>-mthumb
-<compileflags>-Wformat
-<compileflags>-Werror=format-security
-<compileflags>-Wall
-<compileflags>-Wshadow
-;
 EOF
 }
 

--- a/boost.sh
+++ b/boost.sh
@@ -1079,49 +1079,21 @@ buildBoost_Linux()
     echo > ${OUTPUT_DIR}/linux-build.log
 
     # intel
-    for BITS in 64 32; do
-        for VARIANT in debug release; do
-            echo Building $VARIANT intel $BITS-bit Boost for Linux
-
-            if [[ $BITS == 64 ]]; then
-                LIBDIR_SUFFIX=x86_64
-            else
-                LIBDIR_SUFFIX=x86
-            fi
-
-            ./b2 $THREADS --build-dir=linux-build --stagedir=linux-build/stage toolset=gcc \
-                --prefix="$OUTPUT_DIR" \
-                --libdir="$OUTPUT_DIR/lib/$VARIANT/$LIBDIR_SUFFIX" \
-                address-model=$BITS variant=$VARIANT \
-                optimization=speed \
-                cxxflags="${CXX_FLAGS} ${CPPSTD}" \
-                link=static threading=multi \
-                install >> "${OUTPUT_DIR}/linux-build.log" 2>&1
-            if [ $? != 0 ]; then echo "Error staging Linux. Check ${OUTPUT_DIR}/linux-build.log"; exit 1; fi
-        done
-    done
-
-    # arm
+    BITS=64
     for VARIANT in debug release; do
-        echo Building $VARIANT arm_gnueabihf Boost for Linux
+        echo Building $VARIANT intel $BITS-bit Boost for Linux
 
-        LIBDIR_SUFFIX=arm_gnueabihf
-        ARCH=arm
-        TOOLSET=gcc-8.3.0~arm
-        ABI=aapcs
+        LIBDIR_SUFFIX=x86_64
 
-        ./b2 $THREADS --build-dir=linux-build --stagedir=linux-build/stage toolset=$TOOLSET \
+        ./b2 $THREADS --build-dir=linux-build --stagedir=linux-build/stage toolset=gcc \
             --prefix="$OUTPUT_DIR" \
             --libdir="$OUTPUT_DIR/lib/$VARIANT/$LIBDIR_SUFFIX" \
             address-model=$BITS variant=$VARIANT \
-            architecture=$ARCH \
-            binary-format=elf \
-            abi=$ABI \
-            optimization=space \
+            optimization=speed \
             cxxflags="${CXX_FLAGS} ${CPPSTD}" \
             link=static threading=multi \
             install >> "${OUTPUT_DIR}/linux-build.log" 2>&1
-        if [ $? != 0 ]; then echo "Error staging Linux. Check ${OUTPUT_DIR}/linux-build.log"; exit 1; fi
+        if [ $? != 0 ]; then echo "Error staging Linux ${BITS}-bit. Check ${OUTPUT_DIR}/linux-build.log"; exit 1; fi
     done
 
     doneSection


### PR DESCRIPTION
* Use the new twilio-video-sdk-toolchain image (version 17), which is based on Ubuntu 20, for linux and android builds.
* Fix issues causing Circle CI validation builds for working branches to fail (boost repo only uses tags, not releases)
* Use the latest Circle CI images for mac builds
* Refactor Circle Ci config to use matrix builds
* Avoid storing unnecessary artifacts (speeds up builds by 10+ minutes)
* Avoid updating brew when installing build tools on mac (speeds up builds further, and Circle anyway keeps the mac machines reasonably up-to-date)
* Avoid caching brew folders for mac builds (no significant benefit)
* Use smaller build machine instances, since large instances don't significantly improve build speed
* Remove builds for linux arm and darwin 32-bit, as those platforms are no longer supported in our SDKs

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
